### PR TITLE
fixed 2 bugs

### DIFF
--- a/kaldiadaptlm/__init__.py
+++ b/kaldiadaptlm/__init__.py
@@ -101,11 +101,11 @@ def kaldi_adapt_lm(kaldi_root, src_model_dir, lm_fn, work_dir, dst_model_name):
     misc.symlink ('%s/egs/wsj/s5/steps' % kaldi_root, '%s/steps' % work_dir)
     misc.symlink ('%s/egs/wsj/s5/utils' % kaldi_root, '%s/utils' % work_dir)
 
-    cmd = 'pushd %s && bash run-adaptation.sh && popd' % work_dir
+    cmd = '/bin/bash -c "pushd %s && bash run-adaptation.sh && popd"' % work_dir
     logging.info (cmd)
     os.system (cmd)
 
-    cmd = 'pushd %s && bash model-dist.sh "%s" && popd' % (work_dir, dst_model_name)
+    cmd = '/bin/bash -c "pushd %s && bash model-dist.sh "%s" && popd"' % (work_dir, dst_model_name)
     logging.info (cmd)
     os.system (cmd)
 

--- a/kaldiadaptlm/templates/kaldi-path.sh.template
+++ b/kaldiadaptlm/templates/kaldi-path.sh.template
@@ -1,4 +1,4 @@
 export KALDI_ROOT={{kaldi_root}}
-export LD_LIBRARY_PATH="$KALDI_ROOT/tools/openfst-1.3.4/lib:$KALDI_ROOT/src/lib:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$KALDI_ROOT/tools/openfst/lib:$KALDI_ROOT/src/lib:$LD_LIBRARY_PATH"
 export PATH=$KALDI_ROOT/src/lmbin/:$KALDI_ROOT/../kaldi_lm/:$PWD/utils/:$KALDI_ROOT/src/bin:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/src/fstbin/:$KALDI_ROOT/src/gmmbin/:$KALDI_ROOT/src/featbin/:$KALDI_ROOT/src/lm/:$KALDI_ROOT/src/sgmmbin/:$KALDI_ROOT/src/sgmm2bin/:$KALDI_ROOT/src/fgmmbin/:$KALDI_ROOT/src/latbin/:$KALDI_ROOT/src/nnetbin:$KALDI_ROOT/src/nnet2bin/:$KALDI_ROOT/src/online2bin/:$KALDI_ROOT/src/ivectorbin/:$KALDI_ROOT/src/kwsbin:$KALDI_ROOT/src/nnet3bin:$KALDI_ROOT/src/chainbin:$PWD:$PATH
 export LC_ALL=C


### PR DESCRIPTION
1) made sure that the pushd command will be executed in bash. My system was complaining about "command not found" due to execution via "sh" as default command-line.

2) removed the version number of openfst in the path-template. It was outdated and there is also a versionless symlink that should be used